### PR TITLE
fixes to make maps less awkward on mobile and focused on task at hand

### DIFF
--- a/website/content/themes/vote-denton/js/app.coffee
+++ b/website/content/themes/vote-denton/js/app.coffee
@@ -46,9 +46,9 @@ marker = null
 
 reset_map = ()->
   marker.setMap(null) if marker
-  map.panToBounds district_bounds
   map.setZoom region_zoom
-
+  map.panToBounds district_bounds
+  console.log district_bounds
 
 
 ###
@@ -199,8 +199,7 @@ mark_point = (point, zoom = detail_zoom, address = "Location" )->
       address: address
 
   infoWindow.open(map, marker)
-
-
+  google.maps.event.addListener infoWindow,'closeclick', reset_map
 
 
 do_map = ()->

--- a/website/content/themes/vote-denton/js/app.js
+++ b/website/content/themes/vote-denton/js/app.js
@@ -75,8 +75,9 @@ Author:
     if (marker) {
       marker.setMap(null);
     }
+    map.setZoom(region_zoom);
     map.panToBounds(district_bounds);
-    return map.setZoom(region_zoom);
+    return console.log(district_bounds);
   };
 
   /*
@@ -336,7 +337,8 @@ Author:
         address: address
       })
     });
-    return infoWindow.open(map, marker);
+    infoWindow.open(map, marker);
+    return google.maps.event.addListener(infoWindow, 'closeclick', reset_map);
   };
 
   do_map = function() {


### PR DESCRIPTION
- clicking on 'close' marker actually closes infowindow, something weird with map_reset()
- disabling a whole bunch of google map UI controls/scrolling, was awkward on mobile
- remove extra variable declarations, fizzbuzz
